### PR TITLE
Enable syntax highlighting in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ due to a need to tweak the main regexp, or possible a corrupt input line.
       3. Callbacks can be used for field validation and event correlation, as the PyReParase instance (which contains the states of all regexp/fields), is available to the callback.
    5. Write the document processing logic...
       1. If all processing logic is implemented as callbacks, the main logic would look like... <i>(TODO: Callbacks implemented soon...)</i>
-         1. ``` 
+         1. ```python
             # Import PyRePrase
             from pyreparse import PyReParse as PRP
             
@@ -73,7 +73,7 @@ due to a need to tweak the main regexp, or possible a corrupt input line.
                   match_def, matched_fields = prp.match(line)
             ```
       2. With or without Callback, you can trigger logic when name-regexp fields match using (see [tests](src/pyreparse/tests/test_pyreparse.py?plain=57#L254) as an example)...
-         1. ```
+         1. ```python
             ...
             
             # Open the input file...


### PR DESCRIPTION
Hey, just noticed you didn't have syntax highlighting enabled for your code blocks.